### PR TITLE
Fix: Set GOCACHE and HOME for gcsfuse build

### DIFF
--- a/ansible/roles/gcsfuse/tasks/os/redhat.yml
+++ b/ansible/roles/gcsfuse/tasks/os/redhat.yml
@@ -38,7 +38,9 @@
     chdir: /tmp/gcsfuse
   become: yes
   environment:
+    HOME: /root
     GOPATH: "/root/go"
+    GOCACHE: /root/.cache/go-build
 
 - name: Symlink Gcsfuse binary to /usr/local/bin
   file:


### PR DESCRIPTION
The gcsfuse build was failing inside of a packer build because the GOCACHE and HOME environment variables were not set for the `go install` command.

This change sets these environment variables in the ansible task to allow the build to complete successfully.